### PR TITLE
Allow for residual or solution tolerances

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,32 +5,50 @@ using RootSolvers
     f(x) = x^2 - 100^2
     f′(x) = 2x
     for FT in [Float32, Float64]
-        sol =
-            find_zero(f, FT(0.0), FT(1000.0), SecantMethod(), CompactSolution())
-        @test sol.converged
-        @test sol.root isa FT
-        @test sol.root ≈ 100
+        for tol in
+            [ResidualTolerance(FT(1e-6)), SolutionTolerance(FT(1e-3)), nothing]
+            sol = find_zero(
+                f,
+                FT(0.0),
+                FT(1000.0),
+                SecantMethod(),
+                CompactSolution(),
+                tol,
+            )
+            @test sol.converged
+            @test sol.root isa FT
+            @test sol.root ≈ 100
 
-        sol = find_zero(
-            f,
-            FT(0.0),
-            FT(1000.0),
-            RegulaFalsiMethod(),
-            CompactSolution(),
-        )
-        @test sol.converged
-        @test sol.root isa FT
-        @test sol.root ≈ 100
+            sol = find_zero(
+                f,
+                FT(0.0),
+                FT(1000.0),
+                RegulaFalsiMethod(),
+                CompactSolution(),
+                tol,
+            )
+            @test sol.converged
+            @test sol.root isa FT
+            @test sol.root ≈ 100
 
-        sol = find_zero(f, FT(1.0), NewtonsMethodAD(), CompactSolution())
-        @test sol.converged
-        @test sol.root isa FT
-        @test sol.root ≈ 100
+            sol =
+                find_zero(f, FT(1.0), NewtonsMethodAD(), CompactSolution(), tol)
+            @test sol.converged
+            @test sol.root isa FT
+            @test sol.root ≈ 100
 
-        sol = find_zero(f, f′, FT(1.0), NewtonsMethod(), CompactSolution())
-        @test sol.converged
-        @test sol.root isa FT
-        @test sol.root ≈ 100
+            sol = find_zero(
+                f,
+                f′,
+                FT(1.0),
+                NewtonsMethod(),
+                CompactSolution(),
+                tol,
+            )
+            @test sol.converged
+            @test sol.root isa FT
+            @test sol.root ≈ 100
+        end
     end
 end
 
@@ -44,7 +62,7 @@ end
             FT(1000.0),
             SecantMethod(),
             CompactSolution(),
-            FT(1e-1),
+            SolutionTolerance(FT(1e-1)),
             1,
         )
         @test !sol.converged
@@ -56,7 +74,7 @@ end
             FT(1000.0),
             RegulaFalsiMethod(),
             CompactSolution(),
-            FT(1e-1),
+            SolutionTolerance(FT(1e-1)),
             1,
         )
         @test !sol.converged
@@ -67,7 +85,7 @@ end
             FT(1.0),
             NewtonsMethodAD(),
             CompactSolution(),
-            FT(1e-1),
+            SolutionTolerance(FT(1e-1)),
             1,
         )
         @test !sol.converged
@@ -79,7 +97,7 @@ end
             FT(1.0),
             NewtonsMethod(),
             CompactSolution(),
-            FT(1e-1),
+            SolutionTolerance(FT(1e-1)),
             1,
         )
         @test !sol.converged


### PR DESCRIPTION
This PR allows for tolerances to be specified on either the solution `x`, or on the residual `f(x)`. Normally, we'd use keywords but there are some remaining issues related to Cassette not being able to forcefully inline things. So, using @jkozdon's functor suggestion, which seems nice and sufficiently flexible. This PR also adds some type restrictions.